### PR TITLE
Fix duplicate in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ jupyter==1.0.0
 jupyterlab==0.34.1
 ipykernel
 pprint
-altair


### PR DESCRIPTION
```
$ pip install -r requirements.txt
Double requirement given: altair (from -r requirements.txt (line 7)) (already in altair==2.2.2 (from -r requirements.txt (line 2)), name='altair')
$ pip --version
pip 18.1 from /usr/local/lib/python3.5/dist-packages/pip (python 3.5)
```